### PR TITLE
Lab 00 Task 2 select open access security group to support tenants without "All Company" group

### DIFF
--- a/Instructions/Labs/LAB[PL-900]_M00Lab00_Setup.md
+++ b/Instructions/Labs/LAB[PL-900]_M00Lab00_Setup.md
@@ -53,24 +53,21 @@ Task #2 – Create environment
 
 1.  If you see a Welcome pop-up, select **Get Started**. 
 
-3. Select **Environments** and select **+ New**.
+1.  Select **Environments** and select **+ New**.
 
-1. For **Name**, enter **[My Initials] Practice** (Example: AJ Practice).
+    1. For **Name**, enter **[My Initials] Practice** (Example: AJ Practice).
 
-    1. For **Type**, choose **Trial** (Do not select the *Trial
-        (subscription-based)* option).
+    1. For **Type**, choose **Trial** (Do not select the *Trial (subscription-based)* option).
 
     1. Change the toggle for **Add a Dataverse data store?** to **Yes**. 
 
     1. Leave all other selections as default and select **Next**. 
 
-    1. On the next tab, leave all selections as default and select **Save**. 
+    1. Click the **+ Select** button under the **Security group** heading.
 
-	6. Select **Next** and then edit **Security group.**
+    1. Select the checkbox for the **None** item under the **Open access** heading and then select **Done**.
 
-	7. Under **Restricted access,** select All Company and then select **Done.**
-
-	7. On the next tab, leave all selections as default and select **Save**.
+    1. Leave the remaining options at their defaults and select **Save**.
 
 1.  Your **Practice** environment should now appear in the list of Environments. 
 


### PR DESCRIPTION
Lab 0, Exercise 1, Task 2

The "Restricted access / All Company" option currently indicated is available only in tenants which have an "All Company" group configured. To support tenants without this particular group, which is not mentioned elsewhere in this repo, change the chosen setting for this option to be the "Open access / None" setting which is available in any tenant.