### PR TITLE
Lab0 - Add guidance for Welcome to Power Apps screen during sign-in

### DIFF
--- a/Instructions/Labs/LAB[PL-900]L0_Validate_lab_environment.md
+++ b/Instructions/Labs/LAB[PL-900]L0_Validate_lab_environment.md
@@ -43,6 +43,8 @@ In this exercise, you will verify that you can access Power Apps.
 
 1. If prompted for contact information, leave the Country/region as the default value and enter `0123456789` for Phone number and select **Submit**.
 
+1. If the **Welcome to Power Apps** screen appears, leave the **Country/region** set to **United States**, and then select **Get started**.
+
 1. At the top right of the screen, verify that the **Environment** is set to **Dev One**. This is where you will be working for the entirety of this lab. If it is not, select the **Dev One** environment.
 
     ![Environment selector.](media/select-dev-one-environment.png)


### PR DESCRIPTION

## Summary
This PR updates the sign-in instructions to account for the **Welcome to Power Apps** screen that may appear for some learners.

## Changes
- Added a conditional step instructing learners to leave the **Country/region** set to **United States** and select **Get started** when the **Welcome to Power Apps** screen appears.

## Files Updated
- `Instructions/Labs/LAB[PL-900]_Validate_lab_environment.md`
