### PR TITLE
Lab 2: Fix and improve Canvas App lab instructions

### DIFF
--- a/Instructions/Labs/LAB[PL-900]Lab2_Canvas_App.md
+++ b/Instructions/Labs/LAB[PL-900]Lab2_Canvas_App.md
@@ -152,7 +152,10 @@ The first thing we want to do is to customize the main screen to include a welco
 
     ![Screenshot of form after fields have been removed.  ](media/452752d064cc0d5150f5d29c194738ff.png)
 
-1.  Select the **Footer** at the bottom of the form.
+> [!NOTE]
+> If a field is missing from the form, select **(x) selected** under **Fields** in the form properties pane, select **+Add field**, and then select the missing column to the form.
+
+11.  Select the **Footer** at the bottom of the form.
 1.  Click **+ Insert** and choose **Button**.
     -   Set its Text to **"Submit"**
     -   Set the button's **OnSelect** property to: **SubmitForm(Form2); Navigate(Facility Requests screen)**

--- a/Instructions/Labs/LAB[PL-900]Lab2_Canvas_App.md
+++ b/Instructions/Labs/LAB[PL-900]Lab2_Canvas_App.md
@@ -66,6 +66,7 @@ In this exercise, you will create a canvas app from one of the built-in template
 1.  Close the App from Preview mode (X button)
 1.  Select the **Save** button.
 1.  Select the **Publish** button.
+1.  Select the **Publish this version** button
 
 # Exercise 2: Build and edit a canvas app
 

--- a/Instructions/Labs/LAB[PL-900]Lab2_Canvas_App.md
+++ b/Instructions/Labs/LAB[PL-900]Lab2_Canvas_App.md
@@ -148,6 +148,8 @@ The first thing we want to do is to customize the main screen to include a welco
 1.  Remove the following fields from the form: (*Select and press Delete*)
     -   Import Sequence Number
     -   Time Zone Rule Version Number
+
+1.  In the form **Properties** pane, set the **Default mode** to **New**.
 1.  Your form should resemble the image below:
 
     ![Screenshot of form after fields have been removed.  ](media/452752d064cc0d5150f5d29c194738ff.png)

--- a/Instructions/Labs/LAB[PL-900]Lab2_Canvas_App.md
+++ b/Instructions/Labs/LAB[PL-900]Lab2_Canvas_App.md
@@ -36,8 +36,12 @@ In this exercise, you will create a canvas app from one of the built-in template
 1.  From the **Home** screen, select **+ Create** from the left navigation pane.
 1.  In the **Start from data** section, select **Upload file**.
 1.  On the **Upload an Excel File** screen, click the **Select from device** button.
-1.  Locate the **Room Reservations.xlsx** file that from the Class Files, select **Open**.
-1.  Ensure that **Use first row as column headers** is selected, and select **Create app**.
+1.  From the **Class Files**, locate and open **Room Reservations.xlsx**.
+
+>[!NOTE]
+>If you only see **Room Reservations.zip**, select the ZIP file, select **Extract All**, open the extracted folder, and then select **Room Reservations.xlsx**.
+
+6.  Ensure that **Use first row as column headers** is selected, and select **Create app**.
 
     ![Build App from File](media/2ffacbe70d4a8f250e7f98423ad280d3.png)
 

--- a/Instructions/Labs/LAB[PL-900]Lab2_Canvas_App.md
+++ b/Instructions/Labs/LAB[PL-900]Lab2_Canvas_App.md
@@ -166,7 +166,7 @@ The first thing we want to do is to customize the main screen to include a welco
 ## Task 4: Add navigation between screens
 
 1.  Go back to the **Facility Requests screen.**
-1.  Select the **RecordGallery1** Gallery
+1.  Select the **RecordsGallery1** Gallery
 1.  On the **Command bar**, select **Insert** and choose **Button**.
     -   Set the buttons text to **"New Room"**.
     -   Set its **OnSelect** property to: **Navigate('New Room Screen')**

--- a/Instructions/Labs/LAB[PL-900]Lab2_Canvas_App.md
+++ b/Instructions/Labs/LAB[PL-900]Lab2_Canvas_App.md
@@ -158,7 +158,8 @@ The first thing we want to do is to customize the main screen to include a welco
 11.  Select the **Footer** at the bottom of the form.
 1.  Click **+ Insert** and choose **Button**.
     -   Set its Text to **"Submit"**
-    -   Set the button's **OnSelect** property to: **SubmitForm(Form2); Navigate(Facility Requests screen)**
+    -   Set the button's **OnSelect** property to the following formula:
+    `SubmitForm(Form2); Navigate('Facility Requests screen')`
 
 ![screenshot showing the submitform Power FX formula](media/40d18e3c6f18a739815dfa3cf182c029.png)
 


### PR DESCRIPTION
## Summary

This PR addresses multiple issues found in the Lab 2 (Canvas App) instructions. The changes fix incorrect references, clarify ambiguous steps, add missing instructions, and correct a Power FX formula to ensure learners can complete the lab without confusion.

## Changes

- **Clarified file opening instructions:** Rewrote the step for locating and opening the Room Reservations Excel file, and added a NOTE with instructions for extracting the file if it is downloaded as a ZIP archive.
- **Added missing Publish step:** Added the "Select the Publish this version button" step at the end of Exercise 1 to complete the correct publishing flow.
- **Improved guidance for missing form fields:** Added a NOTE explaining how to add missing fields back to the form using the Properties pane, so learners are not stuck if a field is absent.
- **Added Form2 DefaultMode step:** Added a new step to set the Form2 Default mode to New in the Properties pane, ensuring the New Room form displays correctly during testing.
- **Corrected Power FX formula:** Fixed the OnSelect formula for the Submit button by wrapping the screen name in single quotes (`'Facility Requests screen'`) and formatting it as inline code for clarity.
- **Fixed gallery name typo:** Replaced the incorrect `RecordGallery1` with the correct `RecordsGallery1` to match the actual component name in Power Apps.

## Files Changed

- `Instructions/Labs/LAB[PL-900]Lab2_Canvas_App.md` — 16 additions, 5 deletions