### PR TITLE
fix(lab0): remove broken hyperlink from Exercise 1 heading

### DIFF
--- a/Instructions/Labs/LAB[PL-900]L0_Validate_lab_environment.md
+++ b/Instructions/Labs/LAB[PL-900]L0_Validate_lab_environment.md
@@ -25,7 +25,7 @@ Tenants must not be converted to a paid subscription. Tenants obtained as a part
 
 ## Exercise 1: Access Microsoft Power Platform
 
-In this exercise, you verify that you can access Power Apps.
+In this exercise, you will verify that you can access Power Apps.
 
 ### Task 1.1 – Sign in to Power Apps
 

--- a/Instructions/Labs/LAB[PL-900]L0_Validate_lab_environment.md
+++ b/Instructions/Labs/LAB[PL-900]L0_Validate_lab_environment.md
@@ -23,9 +23,9 @@ Tenants should not be shared or used for purposes outside of hands-on labs. The 
 
 Tenants must not be converted to a paid subscription. Tenants obtained as a part of this course remain the property of Microsoft Corporation and we reserve the right to obtain access and repossess at any time.
 
-## Exercise 1: Access [Microsoft Power Platform](/power-apps/maker/signup-for-powerapps)
+## Exercise 1: Access Microsoft Power Platform
 
-In this exercise, you will verify that you can access Power Apps.
+In this exercise, you verify that you can access Power Apps.
 
 ### Task 1.1 – Sign in to Power Apps
 


### PR DESCRIPTION
## Summary

Fixes the Exercise 1 heading in Lab 0. The link was causing a confusing underlined heading with no valid destination. The heading text is preserved as plain bold text.

## Changes

- Removed a broken relative hyperlink from the Exercise 1 heading that rendered incorrectly on the lab platform

## Files changed

- `Instructions/Labs/LAB[PL-900]L0_Validate_lab_environment.md` — Exercise 1 heading

## Fixes
Submitted a fix for the issue #165 . The broken hyperlink has been removed from the Exercise 1 heading — the text is preserved as plain text.

Closes #165 