### PR TITLE
fix(lab01): update UI labels and steps to match current Dataverse interface

### DIFF
--- a/Instructions/Labs/LAB[PL-900]Lab1_Data_Model.md
+++ b/Instructions/Labs/LAB[PL-900]Lab1_Data_Model.md
@@ -131,8 +131,8 @@ Next, we will need to create some columns to store information from each request
 
 Next, we are going to add some sample data so when we build apps from the tables, there will be data to display.
 
-1.  Ensure that you still have the Facility Request table editor open.
-1.  Select **Edit**, then select **+ New row** (or select the first empty row) and enter the following sample records:
+1. Ensure that you still have the Facility Request table editor open.
+1. Select **Edit**, then select **+ New row** (or select the first empty row) and enter the following sample records:
 
 | **Request Title**                | **Category** | **Priority** | **Status**  |
 |----------------------------------|--------------|--------------|-------------|
@@ -191,13 +191,16 @@ Now that your table is created, add the following sample data to your table:
 | 233      | South      | Seirra        | 2         | No                  |
 | 401 B    | East       | Jacobson      | 4         | Yes                 |
 
-8. Select the **Save and Exit** button to create your new Room table.
+8. Select the **Save and exit** button to create your new Room table.
+
+1. In the **Done working?** dialog, select **Save and exit**.
+
 
 ## Task 2: Create a Room Lookup field in the Facility Request table.
 
 Next, we are going to add a lookup column to the Facility Request table, that will allow you to select a room from the Rooms table.
 
-1.  Using the left navigation select **Tables**
+1.  In the left navigation pane, select **Tables**.
 1.  Select **All**, and in the **Search** field, enter `Facility`.
 1.  Open the **Facility Request** Table
 1.  Under **Schema**, select **Columns**

--- a/Instructions/Labs/LAB[PL-900]Lab1_Data_Model.md
+++ b/Instructions/Labs/LAB[PL-900]Lab1_Data_Model.md
@@ -108,7 +108,7 @@ Next, we will need to create some columns to store information from each request
 1.  Configure your new column as follows:
     - **Display name:** Category
     - **Data Type:** Choice (Choice)
-1.  Under **Sync with Global Choice**, select **No**.
+1.  Under **Sync with global choice?**, select **No**.
 1.  Under **Choices**, set the **Label** to **Maintenance**.
 1.  Select **+ New Choice** and set the label to **Equipment**.
 1.  Repeat the last step until you have added the following labels:
@@ -132,7 +132,7 @@ Next, we will need to create some columns to store information from each request
 Next, we are going to add some sample data so when we build apps from the tables, there will be data to display.
 
 1.  Ensure that you still have the Facility Request table editor open.
-1.  Select **Edit**, then select **+ New** row (or click into the first empty row) and enter the following sample records:
+1.  Select **Edit**, then select **+ New row** (or select the first empty row) and enter the following sample records:
 
 | **Request Title**                | **Category** | **Priority** | **Status**  |
 |----------------------------------|--------------|--------------|-------------|


### PR DESCRIPTION
﻿## Summary

Updates Lab 01 (Data Model) to fix outdated UI labels, add a missing confirmation dialog step, and apply minor style corrections so the instructions match the current Dataverse maker portal.

## Changes

- Updated **Sync with Global Choice** label to **Sync with global choice?** to match current UI casing
- Fixed **+ New** row button label to **+ New row**
- Replaced "click into the first empty row" with "select the first empty row" per Microsoft style
- Corrected **Save and Exit** button label to **Save and exit**
- Added missing **Done working?** confirmation dialog step after saving the Room table
- Fixed navigation instruction wording to use "In the left navigation pane, select"
- Removed extra leading whitespace on numbered list items for consistent Markdown formatting

## Files changed

- `Instructions/Labs/LAB[PL-900]Lab1_Data_Model.md` - fixed UI labels, added missing dialog step, applied style and formatting corrections
