### PR TITLE
style(lab03): apply Microsoft Learn style and fix UI references

### DIFF
--- a/Instructions/Labs/LAB[PL-900]Lab3_Model_driven_App.md
+++ b/Instructions/Labs/LAB[PL-900]Lab3_Model_driven_App.md
@@ -50,7 +50,7 @@ While employees submit requests using a mobile canvas app, the Contoso facilitie
 1.  Change the **Title** from **New Group** to **Customers.**
 1.  Select the **three dots** next to the **Customers** group and select **New group**.
 1.  Change the **Title** of the **New Group** to **Facilities**.
-1.  Under **Navigation** select the **Facility Requests** view, select **Move Down** until it is in the **Facilities Group**.
+1.  Under **Navigation** select the **Facility Requests** view, and select **Move Down** until it is in the **Facilities Group**.
 1.  Repeat for **Rooms view**, selecting **Move down** until **Rooms** appears below **Facility Requests**.
 1.  Select the **Save** button.
 1.  Your completed App should resemble the image below:
@@ -65,7 +65,7 @@ While employees submit requests using a mobile canvas app, the Contoso facilitie
 1.  In the left navigation pane, select **Tables**. 
 1.  In the search bar at the top-right, type **Facility Request**, and then select the **Facility Request** table from the results.
 1.  Under **Data experiences**, select **Forms**.
-1.  Select the **Information** form where the Form type is Main, select the Commands menu (...), and select Edit > Edit in new tab.
+1.  Select the **Information** form where the **Form type** is **Main**, select the **Commands** menu (...), and select **Edit** > **Edit in new tab**.
 1.  Drag the **Owner** column into the Header area.
 1.  Drag the **Description** column below **Request Title**.
 1.  Drag the **Date Requested** column below **Description**.

--- a/Instructions/Labs/LAB[PL-900]Lab3_Model_driven_App.md
+++ b/Instructions/Labs/LAB[PL-900]Lab3_Model_driven_App.md
@@ -34,8 +34,8 @@ While employees submit requests using a mobile canvas app, the Contoso facilitie
 
 1.  Navigate to Power Apps Maker portal `https://make.powerapps.com` and sign in.
 1.  Select **+ Create** from the left navigation, then select **Blank Page with navigation**.
-1.  Name the app **Contoso Facilities Management** and click **Create**.
-1.  The modern App Designer will open.
+1.  Name the app **Contoso Facilities Management**.
+1.  Select **Create**. The modern app designer will open.
 
 ## Task 2: Add the Facility Request table
 

--- a/Instructions/Labs/LAB[PL-900]Lab3_Model_driven_App.md
+++ b/Instructions/Labs/LAB[PL-900]Lab3_Model_driven_App.md
@@ -47,11 +47,11 @@ While employees submit requests using a mobile canvas app, the Contoso facilitie
 
 1.  Under **Navigation**, select **New Group**.
 1.  On the right side of the screen, expand the **New Group** pane.
-1.  Change the title from **New Group** to **Customers.**
-1.  Select the **three dots** next to the **Customers** group and choose **New group**.
-1.  Change the **Name** of the **New Group** to **Facilities**.
+1.  Change the **Title** from **New Group** to **Customers.**
+1.  Select the **three dots** next to the **Customers** group and select **New group**.
+1.  Change the **Title** of the **New Group** to **Facilities**.
 1.  Under **Navigation** select the **Facility Requests** view, select **Move Down** until it is in the **Facilities Group**.
-1.  Select the **Rooms** view and **Move** it down below **Facility Requests**.
+1.  Repeat for **Rooms view**, selecting **Move down** until **Rooms** appears below **Facility Requests**.
 1.  Select the **Save** button.
 1.  Your completed App should resemble the image below:
 

--- a/Instructions/Labs/LAB[PL-900]Lab3_Model_driven_App.md
+++ b/Instructions/Labs/LAB[PL-900]Lab3_Model_driven_App.md
@@ -39,8 +39,8 @@ While employees submit requests using a mobile canvas app, the Contoso facilitie
 
 ## Task 2: Add the Facility Request table
 
-1.  In the **App Designer**, select **+ Add page** or **+ New**, and choose **Dataverse table**.
-1.  Search for and select both the **Facility Request** and **Rooms** tables (if you completed Lab 1), additionally choose the **Account** and **Contact** tables.
+1.  In the **App Designer**, select **+ Add page** or **+ New**, and select **Dataverse table**.
+1.  Search for and select both the **Facility Request** and **Room** tables (if you completed Lab 1), additionally select the **Account** and **Contact** tables.
 1.  Make sure the **Show in navigation** checkbox is selected and select **Add**. The tables will now appear in your app's navigation.
 
     ![Screenshot of Navigation](media/9444e25f3cc06dcda4d636224bc7a949.png)

--- a/Instructions/Labs/LAB[PL-900]Lab3_Model_driven_App.md
+++ b/Instructions/Labs/LAB[PL-900]Lab3_Model_driven_App.md
@@ -58,10 +58,11 @@ While employees submit requests using a mobile canvas app, the Contoso facilitie
     ![Screenshot of updated navigation ](media/cde7b0696e4a49f586820351b404c066.png)
 
 # Exercise 2: Edit Facility Request form and Facility Request public view
+
 ## Task 1: Modify the Facility Request main form
 
 1.  Open a new tab and navigate to the Power Apps Maker portal `https://make.powerapps.com`
-1.  Make sure you are in the Dev One environment.
+1.  Make sure you are in the **Dev One** environment.
 1.  In the left navigation pane, select **Tables**. 
 1.  In the search bar at the top-right, type **Facility Request**, and then select the **Facility Request** table from the results.
 1.  Under **Data experiences**, select **Forms**.
@@ -80,11 +81,11 @@ While employees submit requests using a mobile canvas app, the Contoso facilitie
 ## Task 2: Modify the Facility Request public view
 
 1.  Navigate to the Power Apps Maker portal `https://make.powerapps.com`
-1.  Make sure you are in the Dev One environment.
+1.  Make sure you are in the **Dev One** environment.
 1.  In the left navigation pane, select **Tables**. 
 1.  In the search bar at the top-right, type **Facility Request**, and then select the **Facility Request** table from the results.
 1.  Under **Data experiences**, select **Views**.
-1.  Select the Active Facility Requests view, select the Commands menu (...), and select Edit > Edit in new tab.
+1.  Select the **Active Facility Requests** view, select the **Commands** menu (...), and select **Edit** > **Edit in new tab**.
 1.  Select the caret next to the **Created On** column and select **Remove**.
 1.  Select the **Description** column to add to the view.
 1.  Select the **Date Requested** column to add to the view.
@@ -101,14 +102,14 @@ While employees submit requests using a mobile canvas app, the Contoso facilitie
 
 1.  Navigate to the Power Apps Maker portal `https://make.powerapps.com`
 1.  In the left navigation pane, select **Apps**.
-1.  Select **Contoso Facilities Management** Model-driven app, select the Commands menu (...), and select Edit.
-1.  Click **Save and Publish** in the upper right.
-1.  Click Play to open the app in a new browser tab.
+1.  Select **Contoso Facilities Management** Model-driven app, select the **Commands** menu (...), and select **Edit**.
+1.  Select **Save and Publish** in the upper right.
+1.  Select **Play** to open the app in a new browser tab.
 1.  Verify the following:
-    -   The navigation menu shows your Facility Request table.
-    -   Clicking the table name shows the list view with the columns you configured.
-    -   Clicking on a record opens the form with the layout you customized.
-    -   You can create a new record by clicking + New.
+    -   The navigation menu shows your **Facility Request** table.
+    -   Selecting the table name shows the list view with the columns you configured.
+    -   Selecting a record opens the form with the layout you customized.
+    -   You can create a new record by selecting **+ New**.
 ****
 
 


### PR DESCRIPTION
## Summary

Applies Microsoft Learn style guidelines and fixes minor inaccuracies in Lab 03 (Model-driven App). Changes replace informal verbs like click and choose with select, bold UI element references, correct the table name from Rooms to Room, and improve step clarity throughout both exercises.

## Changes

### Exercise 1 - Create model-driven application
- **Task 1:** Split the Name and Create step into two discrete actions; lowercased app designer
- **Task 2:** Replaced choose with select for Dataverse table picker; corrected table name from Rooms to Room; changed title label references to Title (bolded); rewrote the Rooms move-down step for clarity

### Exercise 2 - Edit form and view
- **Task 1:** Bolded Dev One, Form type, Main, Commands, and Edit in new tab references
- **Task 2:** Bolded Dev One, Active Facility Requests, Commands, and Edit in new tab references
- **Exercise 3 / Task 1:** Bolded Commands menu reference; replaced Click with Select for Save and Publish and Play buttons; replaced Clicking with Selecting in verification checklist; bolded Facility Request and + New

## Files changed

- `Instructions/Labs/LAB[PL-900]Lab3_Model_driven_App.md` - 21 insertions, 20 deletions applying bold formatting to UI elements, replacing click/choose with select, correcting the Room table name, and improving step wording